### PR TITLE
Refine map sizing and zoom controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,9 @@
         .grid-line { fill: none; stroke: #666; stroke-width: 0.2; opacity: 0.5; pointer-events: none; }
         .country-label { font-family: 'Noto Sans KR', sans-serif; text-anchor: middle; fill: #2c3e50; font-weight: 600; pointer-events: none; paint-order: stroke; stroke: white; stroke-linejoin: round; transition: all 0.1s ease-in-out; }
         .label-hover { fill: #c0392b; }
-        .leader-line { stroke: black; stroke-width: 1; fill: none; }
-        .leader-dot { fill: black; }
+        .zoom-control { display: flex; align-items: center; gap: 8px; }
+        .zoom-btn { width: 32px; height: 32px; border-radius: 50%; border: none; background: linear-gradient(45deg, #667eea, #764ba2); color: #fff; font-size: 1.2rem; line-height: 1; cursor: pointer; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15); transition: transform 0.2s ease, box-shadow 0.2s ease; }
+        .zoom-btn:hover { transform: translateY(-2px); box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4); }
         /* [추가] 국가 목록 패널 스타일 */
         .country-list-panel { position: absolute; top: 0; right: 0; width: calc(100% / 6); height: 100%; background: rgba(255, 255, 255, 0.85); backdrop-filter: blur(5px); transform: translateX(0); transition: transform 0.3s ease-in-out; overflow-y: auto; z-index: 15; border-left: 1px solid rgba(0,0,0,0.1); }
         .country-list-panel.hidden { transform: translateX(100%); }
@@ -49,7 +50,14 @@
             <div class="controls">
                 <div class="control-group"><label>나라 이름</label><label class="toggle"><input type="checkbox" id="showLabels" checked><span class="slider"></span></label></div>
                 <div class="control-group"><label>글자 크기</label><input type="range" id="fontSize" class="size-slider" min="8" max="48" value="9"><span id="fontSizeValue">9px</span></div>
-                <div class="control-group"><label>지도 크기</label><input type="range" id="mapSize" class="size-slider" min="1200" max="6000" value="1200" step="100"><span id="mapSizeValue">1200x600px</span></div>
+                <div class="control-group">
+                    <label>줌</label>
+                    <div class="zoom-control">
+                        <button type="button" class="zoom-btn" id="zoomOutBtn" aria-label="축소">−</button>
+                        <span id="zoomValue">100%</span>
+                        <button type="button" class="zoom-btn" id="zoomInBtn" aria-label="확대">+</button>
+                    </div>
+                </div>
                 <button class="btn" id="toggleListBtn">목록</button>
                 <button class="btn" onclick="downloadPNG()">PNG 다운로드</button>
                 <button class="btn" onclick="downloadSVG()">SVG 다운로드</button>
@@ -71,7 +79,11 @@
         let currentScale = 1, currentX = 0, currentY = 0;
         let isDragging = false, dragStart = { x: 0, y: 0 }, panStart = { x: 0, y: 0 };
         let worldData = null;
-        let mapWidth = 1200, mapHeight = 600;
+        const BASE_MAP_WIDTH = 3840;
+        const BASE_MAP_HEIGHT = 1920;
+        let mapWidth = BASE_MAP_WIDTH, mapHeight = BASE_MAP_HEIGHT;
+        const MAX_SCALE = 5;
+        const MIN_SCALE = 0.01;
 
         const pastelColors = [ '#FFB3BA', '#FFDFBA', '#FFFFBA', '#BAFFC9', '#BAE1FF', '#E0BBE4', '#FFC3A0', '#B5EAD7', '#C7CEEA', '#FFDAB9' ];
         const countryNames = {
@@ -347,23 +359,13 @@
             drawMap();
             updateDynamicSizes(); // [수정] 최초 로드 시에만 글자 크기 자동 조절
             updateCountryList(); // [추가] 초기 국가 목록 업데이트
+            updateZoomDisplay();
         }
-
-        const isOverlapping = (box1, box2) => !(box1.x + box1.width < box2.x || box2.x + box2.width < box1.x || box1.y + box1.height < box2.y || box2.y + box2.height < box1.y);
-        const pointInPolygon = (point, vs) => {
-            const [x, y] = point; let inside = false;
-            for (let i = 0, j = vs.length - 1; i < vs.length; j = i++) {
-                const [xi, yi] = vs[i]; const [xj, yj] = vs[j];
-                if (((yi > y) !== (yj > y)) && (x < (xj - xi) * (y - yi) / (yj - yi) + xi)) inside = !inside;
-            }
-            return inside;
-        };
 
         function drawMap() {
             if (!worldData) return;
             const countryGroup = document.getElementById('countries');
             const labelGroup = document.getElementById('countryLabels');
-            const placedLabelBoxes = [];
 
             worldData.features.forEach((feature, index) => {
                 const { properties, geometry } = feature;
@@ -381,56 +383,20 @@
                 if (countryName) {
                     const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
                     label.setAttribute('class', 'country-label'); label.textContent = countryName; label.dataset.countryCode = countryCode;
-                    labelGroup.appendChild(label); 
+                    labelGroup.appendChild(label);
 
-                    const largestPartCoords = geometry.type === 'Polygon' ? geometry.coordinates[0] : geometry.coordinates.reduce((a, b) => a.flat().length > b.flat().length ? a : b)[0];
-                    const projectedPolygon = largestPartCoords.map(p => mercatorProjection(p[0], p[1]));
+                    const largestPolygon = geometry.type === 'Polygon'
+                        ? geometry.coordinates
+                        : geometry.coordinates.reduce((largest, polygon) => {
+                            const largestLength = largest?.[0]?.length || 0;
+                            const polygonLength = polygon?.[0]?.length || 0;
+                            return polygonLength > largestLength ? polygon : largest;
+                        }, geometry.coordinates[0]);
+                    const largestPartCoords = largestPolygon[0] || [];
                     const centerLonLat = getPolygonCenter(largestPartCoords);
                     const [cx, cy] = mercatorProjection(centerLonLat[0], centerLonLat[1]);
-                    
-                    const labelBBox = label.getBBox(); const countryBBox = path.getBBox();
-                    let needsLeaderLine = (countryBBox.width < labelBBox.width || countryBBox.height < labelBBox.height);
-                    let bestPos = null;
-                    const checkPosition = (x, y) => {
-                        const testBox = { x: x - labelBBox.width / 2, y: y - labelBBox.height / 2, width: labelBBox.width, height: labelBBox.height };
-                        return !placedLabelBoxes.some(placedBox => isOverlapping(testBox, placedBox));
-                    };
-
-                    if (checkPosition(cx, cy)) {
-                        bestPos = { x: cx, y: cy };
-                    } else {
-                        const searchRadius = Math.max(countryBBox.width, countryBBox.height, 30);
-                        for (let r = 5; r < searchRadius && !bestPos; r += 5) {
-                            for (let angle = 0; angle < Math.PI * 2 && !bestPos; angle += Math.PI / 8) {
-                                const testX = cx + r * Math.cos(angle); const testY = cy + r * Math.sin(angle);
-                                if (checkPosition(testX, testY)) bestPos = { x: testX, y: testY };
-                            }
-                        }
-                    }
-
-                    if (bestPos) {
-                        label.setAttribute('x', bestPos.x); label.setAttribute('y', bestPos.y);
-                        if (!needsLeaderLine && !pointInPolygon([bestPos.x, bestPos.y], projectedPolygon)) needsLeaderLine = true;
-                    } else {
-                        needsLeaderLine = true;
-                        label.setAttribute('x', cx + countryBBox.width / 2 + labelBBox.width / 2 + 5); label.setAttribute('y', cy);
-                    }
-                    
-                    const finalBBox = label.getBBox();
-                    placedLabelBoxes.push({ x: finalBBox.x - 5, y: finalBBox.y - 5, width: finalBBox.width + 10, height: finalBBox.height + 10 });
-
-                    if (needsLeaderLine) {
-                        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-                        line.setAttribute('x1', cx); line.setAttribute('y1', cy);
-                        line.setAttribute('x2', label.getAttribute('x') - (finalBBox.width / 2) * (label.getAttribute('x') > cx ? 1 : -1));
-                        line.setAttribute('y2', label.getAttribute('y'));
-                        line.setAttribute('class', 'leader-line');
-                        labelGroup.insertBefore(line, label);
-                        const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-                        dot.setAttribute('cx', cx); dot.setAttribute('cy', cy); dot.setAttribute('r', 1.5);
-                        dot.setAttribute('class', 'leader-dot');
-                        labelGroup.insertBefore(dot, line);
-                    }
+                    label.setAttribute('x', cx);
+                    label.setAttribute('y', cy);
                 }
             });
 
@@ -485,12 +451,18 @@
             const labelGroup = document.getElementById('countryLabels');
             if (labelGroup) labelGroup.style.display = document.getElementById('showLabels').checked ? '' : 'none';
         }
-        
+
+        function updateZoomDisplay() {
+            const zoomValue = document.getElementById('zoomValue');
+            if (zoomValue) {
+                zoomValue.textContent = `${(currentScale * 100).toFixed(0)}%`;
+            }
+        }
+
         function updateCountryList() {
             const listUl = document.getElementById('countryList');
-            const mapContainer = document.getElementById('mapContainer');
             const svgRect = svg.getBoundingClientRect();
-            
+
             const visibleCountries = new Set();
 
             document.querySelectorAll('.country-label').forEach(label => {
@@ -513,29 +485,6 @@
         document.getElementById('showLabels').addEventListener('change', updateLabelStyles);
         document.getElementById('fontSize').addEventListener('input', updateLabelStyles);
         
-        document.getElementById('mapSize').addEventListener('input', function() {
-            const wrapper = document.querySelector('.map-wrapper');
-            const oldWidth = mapWidth;
-            // 현재 스크롤 위치 비율 계산
-            const scrollLeftRatio = wrapper.scrollLeft / (mapWidth - wrapper.clientWidth);
-            const scrollTopRatio = wrapper.scrollTop / (mapHeight - wrapper.clientHeight);
-
-            mapWidth = parseInt(this.value);
-            mapHeight = mapWidth / 2;
-            document.getElementById('mapSizeValue').textContent = `${mapWidth}x${mapHeight}px`;
-            
-            initMap();
-            
-            requestAnimationFrame(() => {
-                // 새로운 스크롤 위치 계산
-                const newScrollLeft = scrollLeftRatio * (mapWidth - wrapper.clientWidth);
-                const newScrollTop = scrollTopRatio * (mapHeight - wrapper.clientHeight);
-
-                wrapper.scrollLeft = newScrollLeft || 0;
-                wrapper.scrollTop = newScrollTop || 0;
-            });
-        });
-        
         document.getElementById('toggleListBtn').addEventListener('click', () => {
             const panel = document.getElementById('countryListPanel');
             panel.classList.toggle('hidden');
@@ -545,29 +494,54 @@
         });
 
         const svg = document.getElementById('worldMap');
-        
+
+        const getViewportCenterPoint = () => {
+            const rect = svg.getBoundingClientRect();
+            const point = svg.createSVGPoint();
+            point.x = rect.width / 2;
+            point.y = rect.height / 2;
+            const ctm = svg.getScreenCTM();
+            return ctm ? point.matrixTransform(ctm.inverse()) : { x: mapWidth / 2, y: mapHeight / 2 };
+        };
+
+        document.getElementById('zoomInBtn').addEventListener('click', () => {
+            const centerPoint = getViewportCenterPoint();
+            applyZoom(currentScale * 1.05, centerPoint);
+        });
+
+        document.getElementById('zoomOutBtn').addEventListener('click', () => {
+            const centerPoint = getViewportCenterPoint();
+            applyZoom(currentScale / 1.05, centerPoint);
+        });
+
         const updateTransform = () => {
             ['gridLines', 'countries', 'countryLabels'].forEach(id => document.getElementById(id)?.setAttribute('transform', `translate(${currentX}, ${currentY}) scale(${currentScale})`));
+            updateZoomDisplay();
             requestAnimationFrame(updateCountryList); // [추가] 변환 후 국가 목록 업데이트
         };
-        
+
+        const applyZoom = (targetScale, focusPoint) => {
+            const focus = focusPoint || { x: mapWidth / 2, y: mapHeight / 2 };
+            const clampedScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, targetScale));
+            const scaleRatio = clampedScale / currentScale;
+            currentX = focus.x - (focus.x - currentX) * scaleRatio;
+            currentY = focus.y - (focus.y - currentY) * scaleRatio;
+            currentScale = clampedScale;
+            updateTransform();
+        };
+
         svg.addEventListener('wheel', e => {
             e.preventDefault();
             const rect = svg.getBoundingClientRect();
-            const point = svg.createSVGPoint(); 
+            const point = svg.createSVGPoint();
             point.x = e.clientX - rect.left; point.y = e.clientY - rect.top;
-            
+
             // 현재 SVG 좌표계에서의 마우스 위치 계산
             const svgPoint = point.matrixTransform(svg.getScreenCTM().inverse());
-            
-            const scaleFactor = e.deltaY > 0 ? 0.9 : 1.1;
-            const newScale = Math.max(0.5, Math.min(50, currentScale * scaleFactor));
 
-            // [수정] 줌 인/아웃 시 마우스 위치 중심으로 변환
-            currentX = svgPoint.x - (svgPoint.x - currentX) * (newScale / currentScale);
-            currentY = svgPoint.y - (svgPoint.y - currentY) * (newScale / currentScale);
-            currentScale = newScale;
-            updateTransform();
+            const scaleFactor = e.deltaY > 0 ? 0.9 : 1.1;
+            const newScale = currentScale * scaleFactor;
+            applyZoom(newScale, svgPoint);
         });
 
         svg.addEventListener('mousedown', e => { isDragging = true; panStart.x = currentX; panStart.y = currentY; dragStart.x = e.clientX; dragStart.y = e.clientY; svg.style.cursor = 'grabbing'; });
@@ -596,12 +570,8 @@
         }
         
         document.addEventListener('DOMContentLoaded', () => {
-            const mapWrapper = document.querySelector('.map-wrapper');
-            mapWidth = mapWrapper.clientWidth;
-            mapHeight = mapWidth / 2;
-            const mapSizeSlider = document.getElementById('mapSize');
-            mapSizeSlider.value = mapWidth;
-            document.getElementById('mapSizeValue').textContent = `${mapWidth}x${mapHeight}px`;
+            mapWidth = BASE_MAP_WIDTH;
+            mapHeight = BASE_MAP_HEIGHT;
             loadWorldData();
         });
     </script>


### PR DESCRIPTION
## Summary
- lock the SVG map container to 3840×1920 and remove the former size slider UI
- simplify country label placement by dropping the overlap-avoidance helpers and leader lines
- add explicit zoom controls that step by 5% increments, display the zoom level, and reuse the new clamped scaling logic for wheel zoom

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc656f12c08327aa1b79b6027d6661