### PR TITLE
Fix world map data loading with local fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,11 +332,28 @@
             return Math.abs(area / 2);
         };
 
+        async function fetchWithFallback(urls) {
+            let lastError = null;
+            for (const url of urls) {
+                try {
+                    const response = await fetch(url);
+                    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                    return response;
+                } catch (error) {
+                    lastError = error;
+                    console.warn(`Failed to load map data from ${url}:`, error);
+                }
+            }
+            throw lastError ?? new Error('Unknown error while loading map data');
+        }
+
         async function loadWorldData() {
             const loadingIndicator = document.getElementById('loadingIndicator');
             try {
-                const response = await fetch('https://tb.tues.myds.me/ne_50m_admin_0_countries.json');
-                if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                const response = await fetchWithFallback([
+                    'ne_50m_admin_0_countries.json',
+                    'https://tb.tues.myds.me/ne_50m_admin_0_countries.json'
+                ]);
                 worldData = await response.json();
                 worldData.features.forEach(f => {
                     if (!f.geometry) return;
@@ -346,7 +363,10 @@
                 worldData.features.sort((a, b) => b.properties.calculatedArea - a.properties.calculatedArea);
                 loadingIndicator.style.display = 'none';
                 initMap();
-            } catch (error) { loadingIndicator.textContent = '지도 데이터 로드에 실패했습니다.'; }
+            } catch (error) {
+                console.error('Failed to load world map data:', error);
+                loadingIndicator.textContent = '지도 데이터 로드에 실패했습니다.';
+            }
         }
         
         function initMap() {


### PR DESCRIPTION
## Summary
- add a fetch helper that first tries to load the bundled GeoJSON file and falls back to the remote copy
- keep users informed by logging failures and reusing the existing loading indicator message

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd58bb05a88327930e04be90c177ee